### PR TITLE
filehmac: fix incorrect length type

### DIFF
--- a/src/filehmac.c
+++ b/src/filehmac.c
@@ -214,7 +214,7 @@ compute_file_hmac(const char *path, void **buf, size_t *hmaclen, int force_fips)
 	OSSL_PARAM params[2];
 	unsigned char rbuf[READ_BUFFER_LENGTH];
 	size_t len;
-	unsigned int hlen;
+	size_t hlen;
 
 	if (force_fips && fips == NULL) {
 		fips = OSSL_PROVIDER_load(NULL, "fips");


### PR DESCRIPTION
EVP_MAC_final() expects a size_t type variable for storing the number of bytes written, but the the variable was declared as unsigned int, causing the function to write 0 to the variable while the actual hmac computation actually successfully completes.